### PR TITLE
Mitigate session fixation during login

### DIFF
--- a/src/FormAuthenticator.php
+++ b/src/FormAuthenticator.php
@@ -124,6 +124,9 @@ class FormAuthenticator extends AbstractAuthenticator
             $this->onFailure($realm, $servletRequest, $servletResponse);
             return false;
         }
+        
+        // renew the session identifier to mitigate session fixation
+        $session->renewId();
 
         // invoke the onSuccess callback and redirect the user to the original page
         $this->onSuccess($userPrincipal, $servletRequest, $servletResponse);


### PR DESCRIPTION
Renew the session identifier after successful login in order to prevent session fixation.
Depends on https://github.com/appserver-io/appserver/pull/1146